### PR TITLE
Update bruteforce.cmd to include error handling for no named networks

### DIFF
--- a/Source Code/bruteforce.cmd
+++ b/Source Code/bruteforce.cmd
@@ -396,6 +396,10 @@
 				set /a keynumber=!keynumber! + 1
 				set current_ssid=%%d
 
+				if "!current_ssid!"=="" (
+					set "current_ssid=Hidden_Network"
+				)
+
 				call :character_finder_2 "!current_ssid!"
 
 			)


### PR DESCRIPTION
got the fix from ebola man (linked [here](https://www.youtube.com/watch?v=HoEGN7dKqC0)), I just thought it could be useful to fix the crash right from the download button